### PR TITLE
Fix bug

### DIFF
--- a/src/Model/Model.Common/Leg.cs
+++ b/src/Model/Model.Common/Leg.cs
@@ -66,10 +66,10 @@ public class Leg : ILeg
 
 		var isTurnValid = this.IsTurnValid(legRules, turn);
 
-		if (!isTurnValid)
-			return 0;
-
 		var currentPoints = this.GetCurrentPlayerPoints();
+		if (!isTurnValid)
+			return legRules.TargetScore - currentPoints;
+
 		return legRules.TargetScore - (currentPoints + turn.ThrownPoints);
 	}
 


### PR DESCRIPTION
When an invalid throw was being made, GetRemainingPointsAfterTurn would return 0, causing the input match modal to show that the leg was ending, which obviously isn't right.
This pull request makes GetRemainingPointsAfterTurn return the right number for invalid throws.