### PR TITLE
Remove export button

### DIFF
--- a/src/View/View.Common/Screen/MatchOverview/MatchOverviewScreen.cs
+++ b/src/View/View.Common/Screen/MatchOverview/MatchOverviewScreen.cs
@@ -270,12 +270,5 @@ internal class MatchOverviewScreen : Screen
 
 		if (ImGuiExtensions.Button("Back", new Vector2(120, 0)))
 			this.ScreenNavigator.Pop();
-
-		ImGui.SameLine();
-
-		if (ImGuiExtensions.Button("Export", new Vector2(120, 0)))
-		{
-
-		}
 	}
 }


### PR DESCRIPTION
There was an unused 'export' button on the matchOverview screen. This PR removes that button.